### PR TITLE
Output format bugfixes

### DIFF
--- a/source/SharpLinter/SharpLinterBatch.cs
+++ b/source/SharpLinter/SharpLinterBatch.cs
@@ -17,7 +17,7 @@ namespace JTC.SharpLinter.Config
         {
             get
             {
-                if (!String.IsNullOrEmpty(Configuration.OutputFormat))
+                if (HasCustomOutputFormat())
                 {
                     return Configuration.OutputFormat;
                 }
@@ -209,8 +209,13 @@ namespace JTC.SharpLinter.Config
 
                 foreach (JsLintData error in allErrors)
                 {
-                    string character = error.Character>=0 ? "at character " + error.Character : String.Empty;
-                    Console.WriteLine(string.Format(OutputFormat, error.FilePath, error.Line, error.Source, error.Reason,character));
+                    string character = error.Character.ToString();
+                    // add a small introducing string before the character number if we are using the default output string
+                    if (!HasCustomOutputFormat())
+                    {
+                        character = error.Character >= 0 ? "at character " + error.Character : String.Empty;
+                    }
+                    Console.WriteLine(string.Format(OutputFormat, error.FilePath, error.Line, error.Source, error.Reason, character));
                 }
             }
             if (Configuration.Verbosity == Verbosity.Debugging)
@@ -245,6 +250,11 @@ namespace JTC.SharpLinter.Config
         private int LintDataComparer(JsLintData x, JsLintData y)
         {
             return x.Line.CompareTo(y.Line);
+        }
+
+        private bool HasCustomOutputFormat()
+        {
+            return !String.IsNullOrEmpty(Configuration.OutputFormat);
         }
     }
 }

--- a/source/SharpLinterExe/Program.cs
+++ b/source/SharpLinterExe/Program.cs
@@ -115,6 +115,7 @@ namespace JTC.SharpLinter
                     {
                         case "-of":
                             finalConfig.OutputFormat = value.Replace("\\r", "\r").Replace("\\n", "\n");
+                            i++;
                             break;
                         case "-i":
                             finalConfig.IgnoreStart = value;


### PR DESCRIPTION
Here's a new pull request for two things that have been bothering me:
- 8e4849da6e730e3bae118104ef024e26617e3d39 fixes a bug where the -of parameter's value is incorrectly added to the file list, generated an "Ignoring file" message in the output
- b644f3a825807b754f38f1008e45d092ca2e5314 changes the way the output format is processed so that {4} only contains the number of the character where the error occurs, and not " at character x", which made it impossible for me to get properly formatted messages for Visual Studio. Note that I kept the default behaviour: if the output format has not been customised, it still outputs " at character x", as it did before.
